### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the extracurricular activities list, as announced by the principal in the school assembly.

Fixes #6

## Changes

- Added `GitHub Skills` entry to the `activities` dictionary in `src/app.py`
  - Description: Learn practical coding and collaboration skills through GitHub's certification program
  - Schedule: Wednesdays, 3:30 PM - 4:30 PM
  - Max participants: 25

Students can now find and sign up for the GitHub Skills activity on the website before registration closes at the end of this week.